### PR TITLE
Fix search ffms2.dll and call FFMS_Init for MINGW

### DIFF
--- a/.github/workflows/pyffms2.yml
+++ b/.github/workflows/pyffms2.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Install pyffms2
       run: |
-        $VERS = "0.4.5"
+        $VERS = "0.4.5.2"
         $LINK = "https://github.com/bubblesub/pyffms2/releases/download/$VERS"
         $PKG = "ffms2.zip"
         curl -LO "$LINK/$PKG"

--- a/ffms2/__init__.py
+++ b/ffms2/__init__.py
@@ -165,9 +165,7 @@ DEFAULT_AUDIO_FILENAME_FORMAT = "%sourcefile%_track%trackzn%.w64"
 PIX_FMT_NONE = FFMS_GetPixFmt(b"none")
 
 
-if os.name == "nt":
-    import atexit
-    import pythoncom  # @UnresolvedImport
+if os.name == "nt": 
 
     # http://code.google.com/p/ffmpegsource/issues/detail?id=58
     USE_UTF8_PATHS = True
@@ -205,7 +203,12 @@ if os.name == "nt":
         pythoncom.CoUninitialize()
         pythoncom._initialized = False
 
-    ffms_init()
+    if "[GCC" in sys.version: # pythoncom is part of pypiwin32 which cannot be installed on MINGW
+        FFMS_Init(0, USE_UTF8_PATHS)
+    else:
+        import atexit 
+        import pythoncom  # @UnresolvedImport
+        ffms_init()
 else:
     FILENAME_ENCODING = sys.getfilesystemencoding()
 

--- a/ffms2/get_library.py
+++ b/ffms2/get_library.py
@@ -86,6 +86,9 @@ if os.name == "nt":
         except NameError:
             script_dirs = []
         script_dirs.append(absdir(sys.argv[0]))
+        if "[GCC" in sys.version: # in MINGW ffms2.dll with name libffms2-?.dll located in /bin
+            script_dirs.append(absdir(sys.executable))
+            win_formats+=["lib{}%s.dll"%(x or "") for x in range(0, -9, -1)]
         for win_format in win_formats:
             dll_name = win_format.format(name)
             for script_dir in script_dirs:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 install_packages = ["numpy"]
-if os.name == "nt":
+if os.name == "nt" and "[GCC" not in sys.version: # pypiwin32 now сannot be installed to MINGW
     install_packages.append("pypiwin32")
 
 libs = ["ffms2.dll", "ffms2.lib", "ffmsindex.exe"]


### PR DESCRIPTION
`pacman -S ${MINGW_PACKAGE_PREFIX}-ffms2` place libffms2-?.dll to /bin
not to /windows with name ffms2.dll

For MINGW pywin32 not found in repos: `pacman -Ss python-pywin32`
(look: msys2/MINGW-packages#751)
and cannot be installed with `pip install pypiwin32`
Therefore, it is not possible to use pythoncom
(look: https://github.com/bubblesub/pyffms2/pull/21)